### PR TITLE
fix pulse weapons not saving upgrades

### DIFF
--- a/StarTech/startech/ui/configurator/tree.lua
+++ b/StarTech/startech/ui/configurator/tree.lua
@@ -47,6 +47,7 @@ local function saveItem(itm)
     )
   end
   
+  cfgSlot:setItem(nil) --see https://github.com/zetaPRIME/sb.StardustSuite/pull/25
   cfgSlot:setItem(itm)
 end
 


### PR DESCRIPTION
should be self explanatory :з

after some digging(this is my first time touching anything LUA :D) i think this is the culprit:
https://github.com/zetaPRIME/sb.StardustSuite/blob/51592a8d6788151884a4801f0136e16ab782e691/StardustLib/sys/metagui/widgets.lua#L907
this :arrow_up: check prevents insertion of updated item here :arrow_down: 
https://github.com/zetaPRIME/sb.StardustSuite/blob/51592a8d6788151884a4801f0136e16ab782e691/StarTech/startech/ui/configurator/tree.lua#L50
which in turn "reverts" weapon to its old state, thus wasting AP

due to my unfamiliarity with SB internals i decided to not touch anything in widgets.lua and instead propose this ugly workaround
though something tells me that this issue will require better solution in the long term  >.<